### PR TITLE
Adds more control over OnLeader/OnFollower state changes and resolves #6

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,38 +8,54 @@ doing things.
 package main
 
 import (
+	"flag"
 	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"strings"
+
 	"github.com/upsight/dinghy"
 )
 
-
 func main() {
-	addr := "localhost:8899"
-	nodes := []string{"localhost:8899", "localhost:8898", "localhost:8897"}
+	addr := flag.String("addr", "localhost:8899", "The address to listen on.")
+	nodesList := flag.String("nodes", "localhost:8898,localhost:8897", "Comma separated list of host:port")
+	flag.Parse()
+
+	nodes := strings.Split(*nodesList, ",")
+	nodes = append(nodes, *addr)
 
 	onLeader := func() error {
 		fmt.Println("leader")
+		return nil
 	}
 	onFollower := func() error {
-		fmt.Println("follower")
+		fmt.Println("me follower")
+		return nil
 	}
 
 	din, err := dinghy.New(
-		addr,
+		*addr,
 		nodes,
 		onLeader,
 		onFollower,
-		&dinghy.LogLogger{},
+		&dinghy.LogLogger{Logger: log.New(os.Stderr, "logger: ", log.Lshortfile)},
 		dinghy.DefaultElectionTickRange,
 		dinghy.DefaultHeartbeatTickRange,
 	)
 	if err != nil {
 		log.Fatal(err)
 	}
-	for _, route := din.Routes() {
-		http.Handle(route.Path, route.Handler)
+	for _, route := range din.Routes() {
+		http.HandleFunc(route.Path, route.Handler)
 	}
-	log.Fatal(http.ListenAndServe(addr, nil))
+	go func() {
+		if err := din.Start(); err != nil {
+			log.Fatal(err)
+		}
+	}()
+	log.Fatal(http.ListenAndServe(*addr, nil))
 }
 ```
 

--- a/dinghy.go
+++ b/dinghy.go
@@ -110,11 +110,15 @@ func (d *Dinghy) Start() error {
 		}
 		switch d.State.State() {
 		case StateFollower:
-			d.follower()
+			if err := d.follower(); err != nil {
+				return err
+			}
 		case StateCandidate:
 			d.candidate()
 		case StateLeader:
-			d.leader()
+			if err := d.leader(); err != nil {
+				return err
+			}
 		default:
 			return fmt.Errorf("unknown state %d", d.State.State())
 		}
@@ -123,23 +127,23 @@ func (d *Dinghy) Start() error {
 
 // follower will wait for an AppendEntries from the leader and on expiration will begin
 // the process of leader election with a RequestVote.
-func (d *Dinghy) follower() {
+func (d *Dinghy) follower() error {
 	d.logger.Println("entering follower state, leader id", d.State.LeaderID())
-	err := d.OnFollower()
-	if err != nil {
+	if err := d.OnFollower(); err != nil {
 		d.logger.Errorln("executing OnFollower", err)
+		return err
 	}
 LOOP:
 	for {
 		select {
 		case <-d.stopChan:
-			return
+			return nil
 		case newState := <-d.State.StateChanged():
 			if newState == StateFollower {
 				continue
 			}
 			d.logger.Println("follower state changed to", d.State.StateString(newState))
-			return
+			return nil
 		case <-d.State.HeartbeatReset():
 			d.logger.Println("heartbeat reset")
 			continue LOOP
@@ -158,7 +162,7 @@ LOOP:
 			d.State.LeaderID(UnknownLeaderID)
 			d.State.Term(d.State.Term() + 1)
 			d.State.State(StateCandidate)
-			return
+			return nil
 		}
 	}
 }
@@ -223,17 +227,25 @@ func (d *Dinghy) candidate() {
 
 // leader is for when in StateLeader. The loop will continually send
 // a heartbeat of AppendEntries to all peers at a rate of HeartbeatTimeoutMS.
-func (d *Dinghy) leader() {
+func (d *Dinghy) leader() error {
 	d.logger.Println("entering leader state")
-	err := d.OnLeader()
-	if err != nil {
-		d.logger.Errorln("executing OnLeader", err)
-	}
 	go d.AppendEntriesRequest()
+	errChan := make(chan error)
+	go func() {
+		// Run the OnLeader event in a goroutine in case
+		// it has a long delay. Any errors returned will exit the
+		// leader state.
+		if err := d.OnLeader(); err != nil {
+			d.logger.Errorln("executing OnLeader", err)
+			errChan <- err
+		}
+	}()
 	for {
 		select {
+		case err := <-errChan:
+			return err
 		case <-d.stopChan:
-			return
+			return nil
 		case <-d.State.AppendEntriesEvent():
 			// ignore any append entries to self.
 			continue
@@ -242,7 +254,7 @@ func (d *Dinghy) leader() {
 				continue
 			}
 			d.logger.Println("leader state changed to", d.State.StateString(newState))
-			return
+			return nil
 		case h := <-d.State.HeartbeatTick():
 			d.logger.Println("sending to peers AppendEntriesRequest", d.Nodes, h)
 			currentTerm, err := d.AppendEntriesRequest()
@@ -251,7 +263,7 @@ func (d *Dinghy) leader() {
 				switch err {
 				case ErrNewElectionTerm:
 					d.State.StepDown(currentTerm)
-					return
+					return nil
 				}
 			}
 		}

--- a/dinghy_test.go
+++ b/dinghy_test.go
@@ -173,6 +173,11 @@ func TestDinghy_follower(t *testing.T) {
 	go din.leader()
 	time.Sleep(time.Millisecond * 10)
 	din.Stop()
+
+	wantErr := fmt.Errorf("test")
+	din.OnFollower = func() error { return wantErr }
+	err := din.Start()
+	equals(t, wantErr, err)
 }
 
 func TestDinghy_candidate(t *testing.T) {
@@ -219,4 +224,9 @@ func TestDinghy_leader(t *testing.T) {
 	go din.leader()
 	time.Sleep(time.Millisecond * 10)
 	din.Stop()
+
+	wantErr := fmt.Errorf("test")
+	din.OnLeader = func() error { return wantErr }
+	err := din.leader()
+	equals(t, wantErr, err)
 }

--- a/dinghy_test.go
+++ b/dinghy_test.go
@@ -113,6 +113,8 @@ func TestNew(t *testing.T) {
 			}
 			equals(t, got.Addr, tt.want.Addr)
 			equals(t, got.Nodes, tt.want.Nodes)
+			got.mu.Lock()
+			defer got.mu.Unlock()
 			err = got.OnLeader()
 			if (err != nil) != tt.wantLeaderErr {
 				t.Errorf("OnLeader() error = %v, wantErr %v", err, tt.wantLeaderErr)
@@ -175,7 +177,9 @@ func TestDinghy_follower(t *testing.T) {
 	din.Stop()
 
 	wantErr := fmt.Errorf("test")
+	din.mu.Lock()
 	din.OnFollower = func() error { return wantErr }
+	din.mu.Unlock()
 	err := din.Start()
 	equals(t, wantErr, err)
 }
@@ -226,7 +230,11 @@ func TestDinghy_leader(t *testing.T) {
 	din.Stop()
 
 	wantErr := fmt.Errorf("test")
+	din.mu.Lock()
 	din.OnLeader = func() error { return wantErr }
+	din.mu.Unlock()
 	err := din.leader()
 	equals(t, wantErr, err)
+	time.Sleep(time.Millisecond * 10)
+	equals(t, StateFollower, din.State.State())
 }

--- a/log.go
+++ b/log.go
@@ -31,25 +31,25 @@ func (d *DiscardLogger) Errorf(format string, v ...interface{}) {}
 
 // LogLogger uses the std lib logger.
 type LogLogger struct {
-	logger *log.Logger
+	Logger *log.Logger
 }
 
 // Println std lib
 func (d *LogLogger) Println(v ...interface{}) {
-	d.logger.Output(3, "[INFO] "+fmt.Sprintln(v...))
+	d.Logger.Output(3, "[INFO] "+fmt.Sprintln(v...))
 }
 
 // Printf std lib
 func (d *LogLogger) Printf(format string, v ...interface{}) {
-	d.logger.Output(3, fmt.Sprintf("[INFO] "+format, v...))
+	d.Logger.Output(3, fmt.Sprintf("[INFO] "+format, v...))
 }
 
 // Errorln std lib
 func (d *LogLogger) Errorln(v ...interface{}) {
-	d.logger.Output(3, "[ERRO] "+fmt.Sprintln(v...))
+	d.Logger.Output(3, "[ERRO] "+fmt.Sprintln(v...))
 }
 
 // Errorf std lib
 func (d *LogLogger) Errorf(format string, v ...interface{}) {
-	d.logger.Output(3, fmt.Sprintf("[ERRO] "+format, v...))
+	d.Logger.Output(3, fmt.Sprintf("[ERRO] "+format, v...))
 }

--- a/request_test.go
+++ b/request_test.go
@@ -89,28 +89,29 @@ func TestDinghy_RequestVoteRequest(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			nodeResponse := tt.nodeResponse
 			din.State.Term(tt.startTerm)
 			din.State.State(tt.startState)
 			if tt.useNodes {
 				node0 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-					json.NewEncoder(w).Encode(tt.nodeResponse)
+					json.NewEncoder(w).Encode(nodeResponse)
 				}))
 				node1 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-					json.NewEncoder(w).Encode(tt.nodeResponse)
+					json.NewEncoder(w).Encode(nodeResponse)
 				}))
 				node2 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-					json.NewEncoder(w).Encode(tt.nodeResponse)
+					json.NewEncoder(w).Encode(nodeResponse)
 				}))
 				node3 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-					json.NewEncoder(w).Encode(tt.nodeResponse)
+					json.NewEncoder(w).Encode(nodeResponse)
 				}))
 				node4 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-					json.NewEncoder(w).Encode(tt.nodeResponse)
+					json.NewEncoder(w).Encode(nodeResponse)
 				}))
 				din.Nodes = []string{node0.URL, node1.URL, node2.URL, node3.URL, node4.URL}
 			} else {
 				node0 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-					json.NewEncoder(w).Encode(tt.nodeResponse)
+					json.NewEncoder(w).Encode(nodeResponse)
 				}))
 				din.Nodes = []string{node0.URL}
 			}
@@ -164,23 +165,24 @@ func TestDinghy_AppendEntriesRequest(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			nodeResponse := tt.nodeResponse
 			din.State.Term(tt.startTerm)
 			din.State.State(tt.startState)
 			if tt.useNodes {
 				node0 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-					json.NewEncoder(w).Encode(tt.nodeResponse)
+					json.NewEncoder(w).Encode(nodeResponse)
 				}))
 				node1 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-					json.NewEncoder(w).Encode(tt.nodeResponse)
+					json.NewEncoder(w).Encode(nodeResponse)
 				}))
 				node2 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-					json.NewEncoder(w).Encode(tt.nodeResponse)
+					json.NewEncoder(w).Encode(nodeResponse)
 				}))
 				node3 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-					json.NewEncoder(w).Encode(tt.nodeResponse)
+					json.NewEncoder(w).Encode(nodeResponse)
 				}))
 				node4 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-					json.NewEncoder(w).Encode(tt.nodeResponse)
+					json.NewEncoder(w).Encode(nodeResponse)
 				}))
 				din.Nodes = []string{node0.URL, node1.URL, node2.URL, node3.URL, node4.URL}
 			}


### PR DESCRIPTION
Previously if the OnLeader or OnFollower funcs passed in returned an error it was just logged and expected to be handled outside the library. 

This PR changes that behavior by returning error from Start.